### PR TITLE
WPF-42114 Sample of WPF SfDateSelector size change to display more selector items is updated

### DIFF
--- a/SfDatePicker_SelectorSize/MainWindow.xaml
+++ b/SfDatePicker_SelectorSize/MainWindow.xaml
@@ -5,30 +5,24 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:SfDatePicker_SelectorSize"
         xmlns:syncfusion="http://schemas.syncfusion.com/wpf" x:Class="SfDatePicker_SelectorSize.MainWindow"
-        mc:Ignorable="d" xmlns:sfshared="clr-namespace:Syncfusion.Windows.Controls;assembly=Syncfusion.SfShared.Wpf"
+        mc:Ignorable="d"
+        WindowState="Maximized"
+        xmlns:sfshared="clr-namespace:Syncfusion.Windows.Controls;assembly=Syncfusion.SfShared.Wpf"
         Title="MainWindow" Height="350" Width="525">
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition />
             <ColumnDefinition/>
         </Grid.ColumnDefinitions>
-        <syncfusion:SfTimeSelector x:Name="TimeSelector"                                                                     
-                                       AccentBrush="Black"
-                                       Background="Transparent"
-                                       BorderBrush="Transparent"
-                                       BorderThickness="2" ShowCancelButton="False"
-                                       ShowDoneButton="False"
-                                       Header=""  >
-        </syncfusion:SfTimeSelector>
 
-        <syncfusion:SfDateSelector x:Name="DateSelector"
-                                       Grid.Column="1"                                       
-                                       AccentBrush="Black"
-                                       Background="Transparent" Header=""
-                                       BorderBrush="Transparent" FormatString="yyyy-MMM-dd"
-                                       BorderThickness="2"   
-                                       ShowCancelButton="False"
-                                       ShowDoneButton="False">
-        </syncfusion:SfDateSelector>
+        <syncfusion:SfDateSelector x:Name="DateSelector"                                                                     
+                                    AccentBrush="Black" 
+                                    Background="Transparent"
+                                    Header="" 
+                                    BorderBrush="Transparent"
+                                    BorderThickness="2" 
+                                    ShowCancelButton="False"
+                                    ShowDoneButton="False" />
+
     </Grid>
 </Window>

--- a/SfDatePicker_SelectorSize/MainWindow.xaml
+++ b/SfDatePicker_SelectorSize/MainWindow.xaml
@@ -10,11 +10,6 @@
         xmlns:sfshared="clr-namespace:Syncfusion.Windows.Controls;assembly=Syncfusion.SfShared.Wpf"
         Title="MainWindow" Height="350" Width="525">
     <Grid>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition />
-            <ColumnDefinition/>
-        </Grid.ColumnDefinitions>
-
         <syncfusion:SfDateSelector x:Name="DateSelector"                                                                     
                                     AccentBrush="Black" 
                                     Background="Transparent"

--- a/SfDatePicker_SelectorSize/MainWindow.xaml.cs
+++ b/SfDatePicker_SelectorSize/MainWindow.xaml.cs
@@ -30,7 +30,6 @@ namespace SfDatePicker_SelectorSize
         {
             if(this.ActualHeight != 0)
             {
-                TimeSelector.Height = this.ActualHeight;
                 DateSelector.Height = this.ActualHeight;
             }
         }


### PR DESCRIPTION
Hi @jegan,

I have removed the codes for the SfTimeSelector control in this sample. Please review and let me know for changes.

Regards,
Niranjan Kumar